### PR TITLE
add notes about iOS and Capricieux to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ A: Fix your connection.
 **Q: I found a typo or image error, how do I fix it?**  
 A: Open pull request to the corresponding overlay repository.
 
+**Q: How likely is iOS version?**  
+A: Easy if someone manages to make `magiatranslate`-patched version of iOS client app. Impossible otherwise.
+
+**Q: I heard that it was feasible with vanilla `v3.1.9`, is that still true?**  
+A: Not anymore. Vanilla app now points to the `Capricieux` server. See [#12](https://github.com/Puella-Care/totentanz-meta/issues/12) and [#18](https://github.com/Puella-Care/totentanz-meta/pull/18).
+
+**Q: What is `Capricieux`?**  
+A: Separate server in Tokyo designed to strictly separate Archive App from this project. See [`Puella-Care/capricieux`](https://github.com/Puella-Care/capricieux) repository.
+
 **Q: The M-Girl transformation videos are not playing, how to fix?**  
 A: Make sure to enable High Quality Videos in Settings -> Manage Data.  
 Low Quality Videos are also available, but not recommended.


### PR DESCRIPTION
Closes: https://github.com/Puella-Care/totentanz-meta/issues/12

Although this was not unanimous, preservation of Archive App in intended way and delegating access to it to Aniplex was considered more important than possibility of making vanilla `v3.1.9` iOS app work with Totentanz; which is why project Capricieux was implemented.

The biggest issue with using vanilla app is that it would lack `magiatranslate` patches, which are not only vital for separating the downloadable assets server from the rest but also makes English translation much prettier than it could look in the vanilla app.

An alternative plan was to make fully Japanese version of Totentanz based on the vanilla app, making it possible to play the game using `v3.1.9` from Google Play or App Store.
However, the poll for Japanese community had shown that:
- the amount of people who still care about Magia Record as game there is relatively small. Total count of poll participants over a week is less than daily online in Totentanz.
- majority chose Capricieux approach over possibility of iOS version of Totentanz.

This significantly lowered priority for the iOS app, and slightly lowered priority for fully Japanese Android app.
The Japanese Android app is still 100% feasible to implement, it's only a matter of time and resources.
The iOS app (English first) might come in case of any of:
- someone making `magiatranslate`-patched version; this will work with Totentanz without any issues.
- Aniplex updating the Archive App, completely detaching it from Capricieux and freeing it to use with Totentanz again.